### PR TITLE
fix par() lines per CRAN comments

### DIFF
--- a/R/BoneDensityFunctions.R
+++ b/R/BoneDensityFunctions.R
@@ -1015,6 +1015,9 @@ plot_mesh <- function(surface_mesh, density_color = NULL, title = NULL,
   surface_mesh$vb <- rbind(t(vertices), 1)
 
   open3d()
+  oldpar3d <- par3d(skipRedraw = TRUE)  # Save current 3D parameters
+  on.exit(par3d(oldpar3d))              # Ensure they're reset
+
   par3d(windowRect = c(20, 30, 500, 400))
 
   if (!is.null(density_color)) {
@@ -1040,8 +1043,6 @@ plot_mesh <- function(surface_mesh, density_color = NULL, title = NULL,
     legend_colors <- rev(legend_color_sel)
 
     bgplot3d({
-      par(mar = c(5, 4, 4, 2))  # bottom, left, top, right margins
-
       plot.new()
 
       legend("topright", title = expression("Density (mg/cm"^3*")"),
@@ -1147,7 +1148,12 @@ plot_cross_section_bone <- function(surface_mesh,
     slice_val * (max(fill_coords[, axis_index]) - min(fill_coords[, axis_index]))
 
   open3d()
+
+  oldpar3d <- par3d(skipRedraw = TRUE)  # Save current 3D parameters
+  on.exit(par3d(oldpar3d))              # Ensure they're reset
+
   par3d(windowRect = c(20, 30, 500, 400))
+
   shade3d(surface_mesh, color = "gray", alpha = 0.2)
 
   # Clip surface
@@ -1223,7 +1229,6 @@ plot_cross_section_bone <- function(surface_mesh,
   }
 
   bgplot3d({
-    par(mar = c(5, 4, 4, 2))
     plot.new()
     if (legend) {
       if (is.null(legend_color_sel)) {

--- a/man/color_mapping.Rd
+++ b/man/color_mapping.Rd
@@ -35,7 +35,6 @@ maps numeric values to a color
   bone_filepath <- tempfile(fileext = ".stl")
   download.file(url2, bone_filepath, mode = "wb")
   surface_mesh <- import_mesh(bone_filepath)
-
   mat_peak <- voxel_point_intersect(surface_mesh, nifti, ct_eqn = "linear",
                                     ct_params = c(68.4, 1.106),)
   colors <- color_mapping(mat_peak)


### PR DESCRIPTION
CRAN comments:

Please make sure that you do not change the user's options, par or
working directory. If you really have to do so within functions, please
ensure with an *immediate* call of on.exit() that the settings are reset
when the function is exited.
e.g.: -> R/BoneDensityFunctions.R
...
oldpar <- par(no.readonly = TRUE) # code line i
on.exit(par(oldpar)) # code line i + 1
...
par(mfrow=c(2,2)) # somewhere after
...
e.g.:
If you're not familiar with the function, please check ?on.exit. This
function makes it possible to restore options before exiting a function
even if the function breaks. Therefore it needs to be called immediately
after the option change within a function.
For more details:
<[https://contributor.r-project.org/cran-cookbook/code_issues.html#change-of-options-graphical-parameters-and-working-directory](https://urldefense.com/v3/__https:/contributor.r-project.org/cran-cookbook/code_issues.html*change-of-options-graphical-parameters-and-working-directory__;Iw!!DZ3fjg!9jbYEZUF_OpyjymO8-SnR_pY867yOBpLxKTI5oiwNV0JqhUZ3XM-DMTAvQMkiZA6uBocWqc4fgUkCPiHYPU$)>